### PR TITLE
Fix hydration mismatch by stabilizing mock data timestamps

### DIFF
--- a/apps/web/src/crm/mock-data.ts
+++ b/apps/web/src/crm/mock-data.ts
@@ -1,6 +1,15 @@
 import { CONTACT_STAGE_ORDER, DEMO_ORG_ID, type ContactRecord } from "./types";
 
-const now = new Date();
+const MOCK_REFERENCE_TIME = Date.UTC(2024, 3, 18, 15, 0, 0);
+const HOUR_IN_MS = 1000 * 60 * 60;
+
+function hoursAgo(hours: number) {
+  return new Date(MOCK_REFERENCE_TIME - hours * HOUR_IN_MS).toISOString();
+}
+
+function daysAgo(days: number) {
+  return hoursAgo(days * 24);
+}
 
 export const CRM_CONTACTS_SEED: ContactRecord[] = [
   {
@@ -13,13 +22,13 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
     owner: "João Martins",
     assignedTo: "João Martins",
     orgId: DEMO_ORG_ID,
-    lastInteraction: new Date(now.getTime() - 1000 * 60 * 60 * 5).toISOString(),
+    lastInteraction: hoursAgo(5),
     activities: [
       {
         id: "activity-ana-created",
         type: "created",
         actor: "João Martins",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 72).toISOString(),
+        timestamp: daysAgo(3),
         summaryKey: "timeline.events.created",
         summaryValues: { actor: "João Martins" },
       },
@@ -27,7 +36,7 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
         id: "activity-ana-discovery",
         type: "meeting",
         actor: "João Martins",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 24).toISOString(),
+        timestamp: daysAgo(1),
         summaryKey: "timeline.events.discoveryCall",
         summaryValues: { actor: "João Martins" },
       },
@@ -35,7 +44,7 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
         id: "activity-ana-stage",
         type: "stage",
         actor: "João Martins",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 5).toISOString(),
+        timestamp: hoursAgo(5),
         summaryKey: "timeline.events.stageChanged",
         summaryValues: { actor: "João Martins", stage: "discovery", from: "prospecting" },
       },
@@ -51,13 +60,13 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
     owner: "Ana Prado",
     assignedTo: "Paula Ribeiro",
     orgId: DEMO_ORG_ID,
-    lastInteraction: new Date(now.getTime() - 1000 * 60 * 60 * 12).toISOString(),
+    lastInteraction: hoursAgo(12),
     activities: [
       {
         id: "activity-marcelo-created",
         type: "created",
         actor: "Ana Prado",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 144).toISOString(),
+        timestamp: daysAgo(6),
         summaryKey: "timeline.events.created",
         summaryValues: { actor: "Ana Prado" },
       },
@@ -65,7 +74,7 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
         id: "activity-marcelo-email",
         type: "email",
         actor: "Paula Ribeiro",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 24).toISOString(),
+        timestamp: daysAgo(1),
         summaryKey: "timeline.events.proposalSent",
         summaryValues: { actor: "Paula Ribeiro" },
       },
@@ -73,7 +82,7 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
         id: "activity-marcelo-stage",
         type: "stage",
         actor: "Paula Ribeiro",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 12).toISOString(),
+        timestamp: hoursAgo(12),
         summaryKey: "timeline.events.stageChanged",
         summaryValues: { actor: "Paula Ribeiro", stage: "negotiation", from: "discovery" },
       },
@@ -89,13 +98,13 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
     owner: "Ana Prado",
     assignedTo: "Ana Prado",
     orgId: DEMO_ORG_ID,
-    lastInteraction: new Date(now.getTime() - 1000 * 60 * 60 * 48).toISOString(),
+    lastInteraction: daysAgo(2),
     activities: [
       {
         id: "activity-camila-created",
         type: "created",
         actor: "Ana Prado",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 192).toISOString(),
+        timestamp: daysAgo(8),
         summaryKey: "timeline.events.created",
         summaryValues: { actor: "Ana Prado" },
       },
@@ -103,7 +112,7 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
         id: "activity-camila-demo",
         type: "meeting",
         actor: "Ana Prado",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 96).toISOString(),
+        timestamp: daysAgo(4),
         summaryKey: "timeline.events.demoCompleted",
         summaryValues: { actor: "Ana Prado" },
       },
@@ -111,7 +120,7 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
         id: "activity-camila-stage",
         type: "stage",
         actor: "Ana Prado",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 48).toISOString(),
+        timestamp: daysAgo(2),
         summaryKey: "timeline.events.stageChanged",
         summaryValues: { actor: "Ana Prado", stage: "won", from: "negotiation" },
       },
@@ -127,13 +136,13 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
     owner: "João Martins",
     assignedTo: "Isabela Costa",
     orgId: DEMO_ORG_ID,
-    lastInteraction: new Date(now.getTime() - 1000 * 60 * 60 * 8).toISOString(),
+    lastInteraction: hoursAgo(8),
     activities: [
       {
         id: "activity-leo-created",
         type: "created",
         actor: "Isabela Costa",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 48).toISOString(),
+        timestamp: daysAgo(2),
         summaryKey: "timeline.events.created",
         summaryValues: { actor: "Isabela Costa" },
       },
@@ -141,7 +150,7 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
         id: "activity-leo-note",
         type: "note",
         actor: "Isabela Costa",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 8).toISOString(),
+        timestamp: hoursAgo(8),
         summaryKey: "timeline.events.qualifyNote",
         summaryValues: { actor: "Isabela Costa" },
       },
@@ -157,13 +166,13 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
     owner: "João Martins",
     assignedTo: "João Martins",
     orgId: DEMO_ORG_ID,
-    lastInteraction: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 14).toISOString(),
+    lastInteraction: daysAgo(14),
     activities: [
       {
         id: "activity-helena-created",
         type: "created",
         actor: "João Martins",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 45).toISOString(),
+        timestamp: daysAgo(45),
         summaryKey: "timeline.events.created",
         summaryValues: { actor: "João Martins" },
       },
@@ -171,7 +180,7 @@ export const CRM_CONTACTS_SEED: ContactRecord[] = [
         id: "activity-helena-stage",
         type: "stage",
         actor: "João Martins",
-        timestamp: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 14).toISOString(),
+        timestamp: daysAgo(14),
         summaryKey: "timeline.events.stageChanged",
         summaryValues: { actor: "João Martins", stage: "lost", from: "negotiation" },
       },

--- a/apps/web/src/microsites/mock-data.ts
+++ b/apps/web/src/microsites/mock-data.ts
@@ -1,6 +1,22 @@
 import { nanoid } from "nanoid";
 import type { MicrositeActivity, MicrositeLead, MicrositeMember, MicrositeRecord, MicrositeRole } from "./types";
 
+const MICROSITES_REFERENCE_TIME = Date.UTC(2024, 2, 11, 12, 0, 0);
+const MINUTE_IN_MS = 1000 * 60;
+const HOUR_IN_MS = MINUTE_IN_MS * 60;
+
+function minutesAgo(minutes: number) {
+  return new Date(MICROSITES_REFERENCE_TIME - minutes * MINUTE_IN_MS).toISOString();
+}
+
+function hoursAgo(hours: number) {
+  return new Date(MICROSITES_REFERENCE_TIME - hours * HOUR_IN_MS).toISOString();
+}
+
+function daysAgo(days: number) {
+  return hoursAgo(days * 24);
+}
+
 export const DEMO_ORG_ID = "org-demo-001";
 
 export const MICROSITE_MEMBERS: MicrositeMember[] = [
@@ -24,9 +40,9 @@ export const MICROSITES_SEED: MicrositeRecord[] = [
       "Apresente seus serviços de consultoria com formulários acessíveis, integrações nativas e acompanhamento em tempo real.",
     status: "published",
     theme: "light",
-    lastPublishedAt: new Date(Date.now() - 1000 * 60 * 60 * 8).toISOString(),
+    lastPublishedAt: hoursAgo(8),
     totalLeads: 18,
-    lastLeadAt: new Date(Date.now() - 1000 * 60 * 20).toISOString(),
+    lastLeadAt: minutesAgo(20),
     showContactPhone: true,
     enableCaptcha: true,
   },
@@ -45,7 +61,7 @@ export const MICROSITES_SEED: MicrositeRecord[] = [
     theme: "dark",
     lastPublishedAt: null,
     totalLeads: 6,
-    lastLeadAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    lastLeadAt: daysAgo(1),
     showContactPhone: false,
     enableCaptcha: false,
   },
@@ -62,9 +78,9 @@ export const MICROSITES_SEED: MicrositeRecord[] = [
       "Agende uma conversa rápida com nosso time e descubra como aumentar a taxa de conversão com cadência personalizada.",
     status: "published",
     theme: "light",
-    lastPublishedAt: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString(),
+    lastPublishedAt: daysAgo(2),
     totalLeads: 12,
-    lastLeadAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+    lastLeadAt: hoursAgo(5),
     showContactPhone: true,
     enableCaptcha: false,
   },
@@ -75,7 +91,7 @@ export const MICROSITE_ACTIVITIES: MicrositeActivity[] = [
     id: "act-001",
     micrositeId: "ms-001",
     type: "lead",
-    createdAt: new Date(Date.now() - 1000 * 60 * 20).toISOString(),
+    createdAt: minutesAgo(20),
     actorId: "member-rep-1",
     actorName: "Marcos Lima",
     summary: "Lead via microsite — estágio atualizado para 'Novo'.",
@@ -84,7 +100,7 @@ export const MICROSITE_ACTIVITIES: MicrositeActivity[] = [
     id: "act-002",
     micrositeId: "ms-002",
     type: "updated",
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString(),
+    createdAt: hoursAgo(3),
     actorId: "member-leader",
     actorName: "Ana Souza",
     summary: "Layout atualizado com novas perguntas obrigatórias.",
@@ -93,7 +109,7 @@ export const MICROSITE_ACTIVITIES: MicrositeActivity[] = [
     id: "act-003",
     micrositeId: "ms-003",
     type: "published",
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 30).toISOString(),
+    createdAt: hoursAgo(30),
     actorId: "member-rep-1",
     actorName: "Marcos Lima",
     summary: "Microsite republicado com imagens otimizadas.",
@@ -108,7 +124,7 @@ export const MICROSITE_LEADS: MicrositeLead[] = [
     email: "fernanda@empresa.com",
     phone: "+55 11 98800-1020",
     message: "Gostaria de uma demonstração ainda esta semana.",
-    createdAt: new Date(Date.now() - 1000 * 60 * 15).toISOString(),
+    createdAt: minutesAgo(15),
     assignedMemberId: "member-rep-2",
   },
   {
@@ -116,7 +132,7 @@ export const MICROSITE_LEADS: MicrositeLead[] = [
     micrositeId: "ms-003",
     name: "Ricardo Alves",
     email: "ricardo@startup.com",
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+    createdAt: hoursAgo(5),
     assignedMemberId: "member-rep-1",
   },
 ];


### PR DESCRIPTION
## Summary
- replace dynamic Date.now() usage in CRM and microsite mock data with deterministic reference timestamps
- add helper utilities to reuse the fixed time offsets so SSR and CSR renders stay in sync

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dace7ccdb48324939a986b4647eca6